### PR TITLE
Fix Achievement user filter to lookup by UUID

### DIFF
--- a/unicorn/achievements/filters.py
+++ b/unicorn/achievements/filters.py
@@ -33,7 +33,7 @@ class LevelFilter(django_filters.FilterSet):
 class AchievementFilter(django_filters.FilterSet):
     id__in = NumericInFilter(field_name="id", lookup_expr="in")
     q = django_filters.CharFilter(method="search", label=_("Search"))
-    user = django_filters.NumberFilter(method="by_user", label=_("By User"))
+    user = django_filters.UUIDFilter(method="by_user", label=_("By User"))
 
     category = django_filters.ModelMultipleChoiceFilter(
         field_name="category", queryset=Category.objects.all(), label=_("Category")
@@ -58,6 +58,4 @@ class AchievementFilter(django_filters.FilterSet):
         ).distinct()
 
     def by_user(self, queryset, name, value):
-        if not str(value).isdecimal():
-            return queryset
-        return queryset.filter(Q(users__id=value)).distinct()
+        return queryset.filter(Q(users__uuid=value)).distinct()


### PR DESCRIPTION
While playing around with existing Achievement routes I stumbled upon this user filter that didn't quite work. The filter seems to expect a numeric ID and corresponding user `id` field, but looking at current user model/migrations there is only a `uuid` field present. Updated it to expect UUID values and use `uuid` field for lookup.

Example of previously broken lookup: `/api/achievements/achievements/?user=c3961109-045c-43bd-a4d6-329209accddf` (and providing "legacy" numeric id fails because of missing DB column)

Literally (as far as I can remember) my first PR to a Django project ever, so just trying to get my toes wet 😄 