### PR TITLE
Fix issue where serialization of user relations failed

### DIFF
--- a/unicorn/utilities/api.py
+++ b/unicorn/utilities/api.py
@@ -197,7 +197,10 @@ class WritableNestedSerializer(ModelSerializer):
         try:
             return self.Meta.model.objects.get(pk=int(data))
         except (TypeError, ValueError):
-            raise ValidationError("Primary key must be an integer")
+            try:
+                return self.Meta.model.objects.get(pk=data)
+            except (TypeError, ValueError):
+                raise ValidationError("Primary key of invalid type, should likely be an integer")
         except ObjectDoesNotExist:
             raise ValidationError("Invalid ID")
 


### PR DESCRIPTION
Noticed this while trying to post data to create a model that related to a user object.

For example; Posting this user data to `/api/achievements/awards`, results in the `Primary key must be an integer` being thrown
```json
{
    "user": "0cc5dda4-7cc3-4847-b4e1-152e20af65ca",
    "achievement": "2"
}
```

The new version of this checks still tries integer first, but re-tries as undefined type (can it ever be anything else than string on second try?) if that fails.