### PR TITLE
Add support for filtering Award view based on user and achievement

### DIFF
--- a/unicorn/achievements/api/views.py
+++ b/unicorn/achievements/api/views.py
@@ -90,6 +90,7 @@ class AwardViewSet(ModelViewSet):
     queryset = Award.objects.all()
     serializer_class = serializers.AwardSerializer
 
+    filterset_class = filters.AwardFilter
 
 class NfcStationViewSet(ModelViewSet):
     queryset = NfcStation.objects.all()

--- a/unicorn/achievements/filters.py
+++ b/unicorn/achievements/filters.py
@@ -59,3 +59,7 @@ class AchievementFilter(django_filters.FilterSet):
 
     def by_user(self, queryset, name, value):
         return queryset.filter(Q(users__uuid=value)).distinct()
+
+class AwardFilter(django_filters.FilterSet):
+    user = django_filters.UUIDFilter()
+    achievement = django_filters.NumberFilter()


### PR DESCRIPTION
Super useful when wanting to interact with already awarded achievements.

Allows us to show all awards for a given user and achievement combo:
`/api/achivements/awards/?user=<userid>&achievement=<achievementid>`

Making it a lot easier to then `DELETE` or `PUT` an existing award/"user achievement".